### PR TITLE
Rollback runtime dependency

### DIFF
--- a/lib/serial_preference/version.rb
+++ b/lib/serial_preference/version.rb
@@ -1,3 +1,3 @@
 module SerialPreference
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/serial_preference.gemspec
+++ b/serial_preference.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "activesupport", ">= 6.0.0"
-  gem.add_runtime_dependency "activerecord", ">= 6.0.0"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.0"
+  gem.add_runtime_dependency "activerecord", ">= 3.0.0"
 
   gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'rspec', ">= 3.0.0"


### PR DESCRIPTION
We don't need to limit an `activerecord` and `activesupport` versions to `>= 6.0.0`.