### PR TITLE
INT2-1703 fix for rails 7.0.8.1

### DIFF
--- a/lib/serial_preference/has_preference_map.rb
+++ b/lib/serial_preference/has_preference_map.rb
@@ -32,7 +32,7 @@ module SerialPreference
       private
 
       def build_preference_definitions
-        if Rails.version.starts_with?('7')
+        if Rails.version.starts_with?('7.1')
           serialize self._preferences_attribute, coder: YAML, type: Hash
         else
           serialize self._preferences_attribute, Hash


### PR DESCRIPTION
This PR is created for below reason -
Repo - https://github.com/punchh/auth-service is currently running on rails -  7.0.8.1 in this repo while integrating preference_serializer is throwing error. Found this issue in 'lib/serial_preference/has_preference_map.rb' Code is managed for rails 7 and above but for rails -  7.0.8.1 it's working with else part. 


